### PR TITLE
Procedural interstage for station structural adapters.

### DIFF
--- a/GameData/Jso/Bdb/PF/bdb_pf.cfg
+++ b/GameData/Jso/Bdb/PF/bdb_pf.cfg
@@ -156,6 +156,24 @@
 	}
 }
 
+//Interstage adapter module for station structural adapters
+@PART[bluedog_Gemini_1p5mEndcap_PF,bluedog_Gemini_1p875mLongAdapter_PF,bluedog_Gemini_StructuralEndcap_PF,bluedog_MOL_Adapter_15_125_PF,bluedog_MOL_Adapter_1875_15_PF]:FOR[Jso_Bdb_PF]:NEEDS[ProceduralFairings]
+{
+	MODULE
+	{
+			name = ProceduralFairingAdapter
+			baseSize = #$../tempBaseSize$
+			topSize = #$../tempBaseSize$
+			height = 2.0
+			costPerTonne = 1000
+			specificMass = 0.006, 0.013, 0.010, 0
+			specificBreakingForce = 6050
+			specificBreakingTorque = 6050
+			dragAreaScale = 1.5
+			topNodeDecouplesWhenFairingsGone = False
+	}
+}
+
 @PART[bluedog*,Bluedog*]:HAS[@MODULE[ProceduralFairingBase]]:AFTER[Jso_Bdb_PF]:NEEDS[ProceduralFairings]
 {
 	!extraBaseRadius = delete


### PR DESCRIPTION
Since Cobalt added stock fairings to the MOL/Gemini station structural adapters, I thought it would be nice to have the PF interstage module added to the PF versions of those bases created by your patch.

This simply adds the interstage module but does not add the additional attach nodes that usually come with a PF interstage since the purpose here is to shield narrower sections of the station attached to the adapter rather than use it as an actual interstage. The diameter dynamically adapts to whats above but the height needs to be set manually.

![Screenshot 2019-09-20 21 02 06](https://user-images.githubusercontent.com/39182212/65345467-c9c24a00-dbf3-11e9-82a8-a764b8af5eab.png)

![Screenshot 2019-09-20 21 16 59](https://user-images.githubusercontent.com/39182212/65345473-cc24a400-dbf3-11e9-80c1-41106ee76583.png)
